### PR TITLE
Remove scop and add asc order

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -4,7 +4,8 @@ class QuestionsController < ApplicationController
   include CurrentUserConcern
 
   def index
-    @questions = Question.all.map do |q|
+    order = params["sort_order"] || :desc
+    @questions = Question.all.order(:created_at => order) do |q|
 
       user_vote = nil
       if @current_user

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,9 +1,5 @@
 class Question < ApplicationRecord
-  default_scope { order(created_at: :desc) }
-
   belongs_to :user
-
-  default_scope { order(created_at: :asc) }
 
   has_many :user_saved_questions, dependent: :destroy
   has_many :users, through: :user_saved_questions


### PR DESCRIPTION
En está branch removí el scope por defecto y añadí un parámetro llamado 'Sort_order' que el cual recibe el orden en el cual se quieren ordenar las preguntas.  Mientras que no se le pase nada, por defecto sería en orden descendiente, es decir que mostraría las preguntas más recientes primero tal cual estaba antes.